### PR TITLE
Document that it is not safe to run pinst in the prepack step

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ __Important__ if your project is using npm or pnpm, you can achieve the desired 
 {
   "scripts": {
     "postinstall": "<some dev only command>",
-    "prepack": "pinst --disable",
-    "postpack": "pinst --enable"
   }
 }
 ```
 
-_On `prepack`, `postinstall` will be renamed to `_postinstall` (disabled)_
+Before publishing your package, run `pinst --disable`. It will rename the `postinstall` script to `_postinstall` (disabled).
 
-_On `postpack`, it will be renamed back to `postinstall` (enabled)_
+After publishing your package, run `pinst --enable`. It will rename the script back to `postinstall` (enabled).
+
+**Caution**: [It is not safe to run `pinst` in the `prepack` script](https://gist.github.com/djcsdy/3ca078e23fdac4c50e077c84e8284a95).
 
 ## CLI
 


### PR DESCRIPTION
As much discussed in other issues, `"prepack": "pinst --disable"` has never worked as intended. It always results in wrong information going into the npm database. It's just that most tools ignored the wrong information, including npm before npm v10.4.0. See https://gist.github.com/djcsdy/3ca078e23fdac4c50e077c84e8284a95

A lot of projects are starting to get hit by this problem:

 * https://github.com/foray1010/ignore-sync/issues/865
 * https://github.com/react-hookz/deep-equal/issues/269
 * https://github.com/SimenB/add-asset-html-webpack-plugin/issues/373
 * https://github.com/scaffold-eth/create-eth/issues/49
 * https://github.com/bun913/textlint-rule-aws-service-name/issues/96
 * https://github.com/Pustur/whatsapp-chat-parser/issues/256
 * https://github.com/scaffold-eth/create-eth/issues/49

I assume this is just the tip of the iceberg. EVERY historical package that has been published using pinst in the recommended configuration is broken and cannot be installed correctly by npm >= 10.4. This problem is NOT limited to packages that were published recently.

I am seeing a lot of confusion about the underlying cause, which is not really surprising.

I think the only responsible course of action is to immediately stop recommending that developers use pinst in their `prepack` and `postpack` scripts since this results in broken packages and always has done.

Unfortunately the only safe way I know of to run pinst is to run it BEFORE `yarn publish`. There's no safe way I know of to cause `yarn publish` to run `pinst --disable` automatically. It's unfortunate that the solution is so unergonomic, but the only alternative is many broken packages.

Fixes #22, #23.