### PR TITLE
Replace postinstall script with prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,9 @@
     "test": "jest",
     "lint": "eslint .",
     "fix": "npm run lint -- --fix",
-    "postinstall": "husky install",
+    "prepare": "husky install",
     "preversion": "npm test && npm run lint",
-    "postversion": "git push && git push --tags && npm publish",
-    "prepack": "node bin --disable",
-    "postpack": "node bin --enable"
+    "postversion": "git push && git push --tags && npm publish"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
[It is not safe to run pinst in the prepack script](https://gist.github.com/djcsdy/3ca078e23fdac4c50e077c84e8284a95).

See also #24, #23, #22.

It seems like a bad idea to keep the broken `prepack` script in the source of pinst itself.

Since we build and publish pinst using npm, not yarn, we can run husky in the `prepare` step instead of `postinstall`. Then we don't need to use pinst to publish pinst :-).

Fixes #26.